### PR TITLE
Update cpt-bootstrap-carousel.php

### DIFF
--- a/trunk/cpt-bootstrap-carousel.php
+++ b/trunk/cpt-bootstrap-carousel.php
@@ -77,7 +77,7 @@ function cptbc_columns_content($column_name, $post_ID) {
 	if ($column_name == 'featured_image') {  
 		$post_featured_image = cptbc_get_featured_image($post_ID);  
 		if ($post_featured_image) {  
-			echo '<img src="' . $post_featured_image . '" />';  
+			echo '<img src="' . $post_featured_image . '" width="70%" />';  
 		}  
 	}  
 }


### PR DESCRIPTION
Well, first of all, thanks for this plugin for WordPress.
I use it in mine projects, I note the little alteration in plugin make a big diference to me.

I think to, why not the options like interval, showcaption and showcontrols are in especifics news sliders backend options? I try make it and suggest a update but my knowlodge for can do that is poor for make it done.
In showcaption and controls, a checkbox for it [show = true, not show = false], and interval a input. Very like with URL option in new slide backend.

Thanks for your time... 

Hugs from Brazil.
