### PR TITLE
Add ability to set 'background-size' property

### DIFF
--- a/trunk/cpt-bootstrap-carousel.php
+++ b/trunk/cpt-bootstrap-carousel.php
@@ -80,5 +80,3 @@ add_action( 'after_setup_theme', 'cptbc_addFeaturedImageSupport');
 require_once('cptbc-admin.php');
 require_once('cptbc-settings.php');
 require_once('cptbc-frontend.php');
-
-?>

--- a/trunk/cptbc-admin.php
+++ b/trunk/cptbc-admin.php
@@ -145,6 +145,3 @@ function cptbc_contextual_help_tab() {
     } // if( $screen->post_type === 'cptbc'){
 add_action('load-post.php', 'cptbc_contextual_help_tab');
 add_action('load-post-new.php', 'cptbc_contextual_help_tab');
-
-?>
-

--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -47,6 +47,7 @@ function cptbc_frontend($atts){
 	if(!isset($atts['image_size'])) $atts['image_size'] = 'full';
 	if(!isset($atts['use_background_images'])) $atts['use_background_images'] = '0';
 	if(!isset($atts['use_javascript_animation'])) $atts['use_javascript_animation'] = '1';
+    if(!isset($atts['select_background_images_style_size'])) $atts['select_background_images_style_size'] = 'cover';
 	if($atts['id'] != ''){
 		$args['p'] = $atts['id'];
 	}

--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -136,5 +136,3 @@ function cptbc_frontend($atts){
 	
 	return $output;
 }
-
-?>

--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -92,7 +92,7 @@ function cptbc_frontend($atts){
 					$linkend = '</a>';
 				}
 			?>
-				<div class="item <?php echo $key == 0 ? 'active' : ''; ?>" id="<?php echo $image['post_id']; ?>" <?php if($atts['use_background_images'] == 1){ echo ' style="height: '.$atts['background_images_height'].'px; background: url(\''.$image['img_src'].'\') no-repeat center center ; -webkit-background-size: cover; -moz-background-size: cover; -o-background-size: cover; background-size: cover;"'; } ?>>
+				<div class="item <?php echo $key == 0 ? 'active' : ''; ?>" id="<?php echo $image['post_id']; ?>" <?php if($atts['use_background_images'] == 1){ echo ' style="height: '.$atts['background_images_height'].'px; background: url(\''.$image['img_src'].'\') no-repeat center center ; -webkit-background-size: ' . $atts['select_background_images_style_size'] . '; -moz-background-size: ' . $atts['select_background_images_style_size'] . '; -o-background-size: ' . $atts['select_background_images_style_size'] . '; background-size: ' . $atts['select_background_images_style_size'] . ';"'; } ?>>
 					<?php if($atts['use_background_images'] == 0){ echo $linkstart.$image['image'].$linkend; } ?>
 					<?php if($atts['showcaption'] === 'true' && strlen($image['title']) > 0 && strlen($image['content']) > 0) { ?>
 						<div class="carousel-caption">

--- a/trunk/cptbc-settings.php
+++ b/trunk/cptbc-settings.php
@@ -488,5 +488,3 @@ function cptbc_settings_link ($links) {
 }
 $cptbc_plugin = plugin_basename(__FILE__); 
 add_filter("plugin_action_links_$cptbc_plugin", 'cptbc_settings_link' );
-
-?>

--- a/trunk/cptbc-settings.php
+++ b/trunk/cptbc-settings.php
@@ -32,7 +32,8 @@ function cptbc_set_options (){
 		'twbs' => '3',
 		'use_background_images' => '0',
 		'background_images_height' => '500',
-        'use_javascript_animation' => '1'
+        'background_images_style_size' => 'cover',
+        'use_javascript_animation' => '1',
 	);
 	add_option('cptbc_settings', $defaults);
 }
@@ -181,6 +182,13 @@ class cptbc_settings_page {
 				'background_images_height', // ID
 				__('Height if using bkgrnd images (px)', 'cpt-bootstrap-carousel'), // Title
 				array( $this, 'background_images_height_callback' ), // Callback
+				'cpt-bootstrap-carousel', // Page
+				'cptbc_settings_setup' // Section
+		);
+		add_settings_field(
+				'background_images_style_size', // ID
+				__('Background images size style', 'cpt-bootstrap-carousel'), // Title
+				array( $this, 'background_images_style_size_callback' ), // Callback
 				'cpt-bootstrap-carousel', // Page
 				'cptbc_settings_setup' // Section
 		);
@@ -418,6 +426,26 @@ class cptbc_settings_page {
 		echo '>No</option>';
 		print '</select>';
         echo '<p class="description">'.__("The Bootstrap Carousel is designed to work usign data-attributes. Sometimes the animation doesn't work correctly with this, so the default is to include a small portion of Javascript to fire the carousel. You can choose not to include this here.", 'cpt-bootstrap-carousel').'</p>';
+	}
+	public function background_images_style_size_callback() {
+		print '<select id="select_background_images_style_size" name="cptbc_settings[select_background_images_style_size]">';
+		print '<option value="cover"';
+		if(isset( $this->options['select_background_images_style_size'] ) && $this->options['select_background_images_style_size'] === 'cover'){
+			print ' selected="selected"';
+		}
+		echo '>Cover (default)</option>';
+		print '<option value="contain"';
+		if(isset( $this->options['select_background_images_style_size'] ) && $this->options['select_background_images_style_size'] === 'contain'){
+			print ' selected="selected"';
+		}
+		echo '>Contain</option>';
+		print '<option value="auto"';
+		if(isset( $this->options['select_background_images_style_size'] ) && $this->options['select_background_images_style_size'] === 'auto'){
+			print ' selected="selected"';
+		}
+		echo '>Auto</option>';
+		print '</select>';
+        echo '<p class="description">'.__('If you find that your images are not scaling correctly when using background images try switching the style to \'contain\' or \'auto\'').'</p>';
 	}
     
     // Markup section


### PR DESCRIPTION
I was finding that `background-size: cover` wasn't working for me, whilst playing around with the CSS `background-size: contain` was working great.

I've added an option to the admin console to set background size property (defaults to **cover** as currently).

Apologies but I'm unsure how to do that language updates (from a language point of view too ;))