### PR TITLE
New option for adding a link to the carousel instead of clickable images

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ As of version 1.5, nearly all of these options can be set in the CPT Bootstrap C
 	
 Credits
 -------
-This plugin was written by @tallphil with help and suggestions from several others including (but not limited to) @reddo, @joshgerdes, @atnon, @grahamharper, @rchq, @oheijo, @smtk, @cla63 and @cookierebes.
+This plugin was written by @tallphil with help and suggestions from several others including (but not limited to) @reddo, @joshgerdes, @atnon, @grahamharper, @rchq, @oheijo, @smtk, @cla63, @cookierebes and @sipman.
 
 The Serbo-Croation translation was kindly provided by Borisa Djuraskovic from http://www.webhostinghub.com
 
@@ -141,6 +141,7 @@ Changelog
   * New settings option to rely on data-attributes only, without any Javascript chunks
   * Split the plugin into multiple files to make code easier to maintain
   * Rewrote the settings page to be clearer
+  * Added new feature to have a link button instead of clickable slider image
 * __1.8.1__
 	* Bugfix. Apologies to anyone who ran into it and thanks to kylewhenderson for the spot.
 * __1.8__

--- a/trunk/cptbc-admin.php
+++ b/trunk/cptbc-admin.php
@@ -54,11 +54,17 @@ function cptbc_image_url(){
 	$custom = get_post_custom($post->ID);
 	$cptbc_image_url = isset($custom['cptbc_image_url']) ?  $custom['cptbc_image_url'][0] : '';
 	$cptbc_image_url_openblank = isset($custom['cptbc_image_url_openblank']) ?  $custom['cptbc_image_url_openblank'][0] : '0';
+	$cptbc_image_link_text = isset($custom['cptbc_image_link_text']) ?  $custom['cptbc_image_link_text'][0] : '';
 	?>
 	<label><?php _e('Image URL', 'cpt-bootstrap-carousel'); ?>:</label>
 	<input name="cptbc_image_url" value="<?php echo $cptbc_image_url; ?>" /> <br />
 	<small><em><?php _e('(optional - leave blank for no link)', 'cpt-bootstrap-carousel'); ?></em></small><br /><br />
-	<label><input type="checkbox" name="cptbc_image_url_openblank" <?php if($cptbc_image_url_openblank == 1){ echo ' checked="checked"'; } ?> value="1" /> <?php _e('Open link in new window?', 'cpt-bootstrap-carousel'); ?></label>
+	
+	<label><input type="checkbox" name="cptbc_image_url_openblank" <?php if($cptbc_image_url_openblank == 1){ echo ' checked="checked"'; } ?> value="1" /> <?php _e('Open link in new window?', 'cpt-bootstrap-carousel'); ?></label><br /><br />
+	
+	<label><?php _e('Button Text', 'cpt-bootstrap-carousel'); ?>:</label>
+	<input name="cptbc_image_link_text" value="<?php echo $cptbc_image_link_text; ?>" /> <br />
+	<small><em><?php _e('(optional - leave blank for default, only shown if using link buttons)', 'cpt-bootstrap-carousel'); ?></em></small>
 	<?php
 }
 function cptbc_admin_init_custpost(){
@@ -74,6 +80,7 @@ function cptbc_mb_save_details(){
 		}
 		update_post_meta($post->ID, "cptbc_image_url", esc_url($_POST["cptbc_image_url"]));
 		update_post_meta($post->ID, "cptbc_image_url_openblank", $openblank);
+		update_post_meta($post->ID, "cptbc_image_link_text", sanitize_text_field($_POST["cptbc_image_link_text"]));
 	}
 }
 add_action('save_post', 'cptbc_mb_save_details');

--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -83,7 +83,7 @@ function cptbc_frontend($atts){
 			<?php foreach ($images as $key => $image) {
 				$linkstart = '';
 				$linkend = '';
-				if($image['url']) {
+				if($image['url'] && $atts['link_button'] == 0) {
 					$linkstart = '<a href="'.$image['url'].'"';
 					if($image['url_openblank']) {
 						$linkstart .= ' target="_blank"';
@@ -98,6 +98,12 @@ function cptbc_frontend($atts){
 						<div class="carousel-caption">
 							<?php echo $atts['before_title'].$linkstart.$image['title'].$linkend.$atts['after_title']; ?>
 							<?php echo $atts['before_caption'].$linkstart.$image['content'].$linkend.$atts['after_caption']; ?>
+							<?php if($image['url'] && $atts['link_button'] == 1){ 
+									if($image['url_openblank']) {
+										$target = ' target="_blank"';
+									}
+									 echo '<a href="'.$image['url'].'" '.$target.' class="'.$atts['link_button_class'].'">'.$atts['link_button_text'].'</a>';
+								 } ?>
 						</div>
 					<?php } ?>
 				</div>

--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -63,9 +63,10 @@ function cptbc_frontend($atts){
 			$image = get_the_post_thumbnail( get_the_ID(), $atts['image_size'] );
 			$image_src = wp_get_attachment_image_src(get_post_thumbnail_id(), $atts['image_size']);
 			$image_src = $image_src[0];
-			$url = get_post_meta(get_the_ID(), 'cptbc_image_url');
-			$url_openblank = get_post_meta(get_the_ID(), 'cptbc_image_url_openblank');
-			$images[] = array('post_id' => $post_id, 'title' => $title, 'content' => $content, 'image' => $image, 'img_src' => $image_src, 'url' => esc_url($url[0]), 'url_openblank' => $url_openblank[0] == "1" ? true : false);
+			$url = get_post_meta(get_the_ID(), 'cptbc_image_url', true);
+			$url_openblank = get_post_meta(get_the_ID(), 'cptbc_image_url_openblank', true);
+			$link_text = get_post_meta(get_the_ID(), 'cptbc_image_link_text', true);
+			$images[] = array('post_id' => $post_id, 'title' => $title, 'content' => $content, 'image' => $image, 'img_src' => $image_src, 'url' => esc_url($url), 'url_openblank' => $url_openblank == "1" ? true : false, 'link_text' => $link_text);
 		}
 	}
 	if(count($images) > 0){
@@ -99,10 +100,16 @@ function cptbc_frontend($atts){
 							<?php echo $atts['before_title'].$linkstart.$image['title'].$linkend.$atts['after_title']; ?>
 							<?php echo $atts['before_caption'].$linkstart.$image['content'].$linkend.$atts['after_caption']; ?>
 							<?php if($image['url'] && $atts['link_button'] == 1){ 
+									if(isset($atts['link_button_before'])) echo $atts['link_button_before'];
+									$target = '';
 									if($image['url_openblank']) {
 										$target = ' target="_blank"';
 									}
-									 echo '<a href="'.$image['url'].'" '.$target.' class="'.$atts['link_button_class'].'">'.$atts['link_button_text'].'</a>';
+									echo '<a href="'.$image['url'].'" '.$target.' class="'.$atts['link_button_class'].'">';
+									if(isset($image['link_text']) && strlen($image['link_text']) > 0) echo $image['link_text'];
+									else echo $atts['link_button_text'];
+									echo '</a>';
+									if(isset($atts['link_button_after'])) echo $atts['link_button_after'];
 								 } ?>
 						</div>
 					<?php } ?>

--- a/trunk/cptbc-settings.php
+++ b/trunk/cptbc-settings.php
@@ -28,6 +28,9 @@ function cptbc_set_options (){
 		'before_caption' => '<p>',
 		'after_caption' => '</p>',
 		'image_size' => 'full',
+		'link_button' => '1',
+		'link_button_text' => 'Read more',
+		'link_button_class' => 'Read more',
 		'id' => '',
 		'twbs' => '3',
 		'use_background_images' => '0',
@@ -193,6 +196,27 @@ class cptbc_settings_page {
 		);
         
         // Markup Section
+		add_settings_field(
+				'link_button', // ID
+				__('Show links as button in caption', 'cpt-bootstrap-carousel'), // Title
+				array( $this, 'link_button_callback' ), // Callback
+				'cpt-bootstrap-carousel', // Page
+				'cptbc_settings_markup' // Section
+		);
+		add_settings_field(
+				'link_button_text', // ID
+				__('Default text for link buttons', 'cpt-bootstrap-carousel'), // Title
+				array( $this, 'link_button_text_callback' ), // Callback
+				'cpt-bootstrap-carousel', // Page
+				'cptbc_settings_markup' // Section
+		);
+		add_settings_field(
+				'link_button_class', // ID
+				__('Class for link buttons', 'cpt-bootstrap-carousel'), // Title
+				array( $this, 'link_button_class_callback' ), // Callback
+				'cpt-bootstrap-carousel', // Page
+				'cptbc_settings_markup' // Section
+		);
 		add_settings_field(
 				'customprev', // ID
 				__('Custom prev button class', 'cpt-bootstrap-carousel'), // Title
@@ -404,6 +428,7 @@ class cptbc_settings_page {
 				isset( $this->options['background_images_height'] ) ? esc_attr( $this->options['background_images_height']) : '500px');
         echo '<p class="description">'.__("If using background images above, how tall do you want the carousel to be?", 'cpt-bootstrap-carousel').'</p>';
 	}
+
 	public function use_javascript_animation_callback() {
 		print '<select id="use_javascript_animation" name="cptbc_settings[use_javascript_animation]">';
 		print '<option value="1"';
@@ -421,6 +446,29 @@ class cptbc_settings_page {
 	}
     
     // Markup section
+	public function link_button_callback(){
+		print '<select id="link_button" name="cptbc_settings[link_button]">';
+		print '<option value="1"';
+		if(isset( $this->options['link_button'] ) && $this->options['link_button'] == 1){
+			print ' selected="selected"';
+		}
+		echo '>Yes (default)</option>';
+		print '<option value="0"';
+		if(isset( $this->options['link_button'] ) && $this->options['link_button'] == 0){
+			print ' selected="selected"';
+		}
+		echo '>No</option>';
+		print '</select>';
+	}
+	public function link_button_text_callback() {
+			printf('<input type="text" id="link_button_text" name="cptbc_settings[link_button_text]" value="%s" size="15" />',
+					isset( $this->options['link_button_text'] ) ? esc_attr( $this->options['link_button_text']) : 'Read more');
+	}
+	public function before_title_callback() {
+			printf('<input type="text" id="link_button_class" name="cptbc_settings[link_button_class]" value="%s" size="6" />',
+					isset( $this->options['link_button_class'] ) ? esc_attr( $this->options['link_button_class']) : 'btn btn-default');
+			echo '<p class="description">'.__("Bootstrap style buttons must have the class <code>btn</code> and then one of the following: <code>btn-default</code>, <code>btn-primary</code>, <code>btn-success</code>, <code>btn-warning</code>, <code>btn-danger</code> or <code>btn-info</code>.", 'cpt-bootstrap-carousel').' <a href="http://getbootstrap.com/css/#buttons-options" target="_blank">Bootstrap documentation</a>.</p>';
+	}
 	public function before_title_callback() {
 			printf('<input type="text" id="before_title" name="cptbc_settings[before_title]" value="%s" size="6" />',
 					isset( $this->options['before_title'] ) ? esc_attr( $this->options['before_title']) : '<h4>');

--- a/trunk/cptbc-settings.php
+++ b/trunk/cptbc-settings.php
@@ -30,7 +30,9 @@ function cptbc_set_options (){
 		'image_size' => 'full',
 		'link_button' => '1',
 		'link_button_text' => 'Read more',
-		'link_button_class' => 'Read more',
+		'link_button_class' => 'btn btn-default pull-right',
+		'link_button_before' => '',
+		'link_button_after' => '',
 		'id' => '',
 		'twbs' => '3',
 		'use_background_images' => '0',
@@ -108,6 +110,12 @@ class cptbc_settings_page {
 				'cpt-bootstrap-carousel' // Page
 		);
 		add_settings_section(
+				'cptbc_settings_link_buttons', // ID
+				__('Link Buttons', 'cpt-bootstrap-carousel'), // Title
+				array( $this, 'cptbc_settings_link_buttons_header' ), // Callback
+				'cpt-bootstrap-carousel' // Page
+		);
+		add_settings_section(
 				'cptbc_settings_markup', // ID
 				__('Custom Markup', 'cpt-bootstrap-carousel'), // Title
 				array( $this, 'cptbc_settings_markup_header' ), // Callback
@@ -173,6 +181,7 @@ class cptbc_settings_page {
 				'cpt-bootstrap-carousel', // Page
 				'cptbc_settings_setup' // Section		   
 		);
+		
 		add_settings_field(
 				'use_background_images', // ID
 				__('Use background images?', 'cpt-bootstrap-carousel'), // Title 
@@ -194,29 +203,45 @@ class cptbc_settings_page {
 				'cpt-bootstrap-carousel', // Page
 				'cptbc_settings_setup' // Section		   
 		);
-        
-        // Markup Section
+
+		// Link buttons
 		add_settings_field(
 				'link_button', // ID
 				__('Show links as button in caption', 'cpt-bootstrap-carousel'), // Title
 				array( $this, 'link_button_callback' ), // Callback
 				'cpt-bootstrap-carousel', // Page
-				'cptbc_settings_markup' // Section
+				'cptbc_settings_link_buttons' // Section
 		);
 		add_settings_field(
 				'link_button_text', // ID
 				__('Default text for link buttons', 'cpt-bootstrap-carousel'), // Title
 				array( $this, 'link_button_text_callback' ), // Callback
 				'cpt-bootstrap-carousel', // Page
-				'cptbc_settings_markup' // Section
+				'cptbc_settings_link_buttons' // Section
 		);
 		add_settings_field(
 				'link_button_class', // ID
 				__('Class for link buttons', 'cpt-bootstrap-carousel'), // Title
 				array( $this, 'link_button_class_callback' ), // Callback
 				'cpt-bootstrap-carousel', // Page
-				'cptbc_settings_markup' // Section
+				'cptbc_settings_link_buttons' // Section
 		);
+		add_settings_field(
+				'link_button_before', // ID
+				__('HTML before link buttons', 'cpt-bootstrap-carousel'), // Title
+				array( $this, 'link_button_before_callback' ), // Callback
+				'cpt-bootstrap-carousel', // Page
+				'cptbc_settings_link_buttons' // Section
+		);
+		add_settings_field(
+				'link_button_after', // ID
+				__('HTML after link buttons', 'cpt-bootstrap-carousel'), // Title
+				array( $this, 'link_button_after_callback' ), // Callback
+				'cpt-bootstrap-carousel', // Page
+				'cptbc_settings_link_buttons' // Section
+		);
+        
+        // Markup Section
 		add_settings_field(
 				'customprev', // ID
 				__('Custom prev button class', 'cpt-bootstrap-carousel'), // Title
@@ -271,7 +296,7 @@ class cptbc_settings_page {
 				if($key == 'interval' && $new_input[$key] == 0){
 					$new_input[$key] = 5000;
 				}
-			} else if ($key == 'before_title' || $key == 'after_title' || $key == 'before_caption' || $key == 'after_caption'){
+			} else if ($key == 'link_button_before' || $key == 'link_button_after' || $key == 'before_title' || $key == 'after_title' || $key == 'before_caption' || $key == 'after_caption'){
 				$new_input[$key] = $input[$key]; // Don't sanitise these, meant to be html!
 			} else { 
 				$new_input[$key] = sanitize_text_field( $input[$key] );
@@ -287,6 +312,9 @@ class cptbc_settings_page {
 	public function cptbc_settings_setup() {
             echo '<p>'.__('Change the setup of the carousel - how it functions.', 'cpt-bootstrap-carousel').'</p>';
 	}
+	public function cptbc_settings_link_buttons_header() {
+            echo '<p>'.__('Options for using a link button instead of linking the image directly.', 'cpt-bootstrap-carousel').'</p>';
+	}
 	public function cptbc_settings_markup_header() {
             echo '<p>'.__('Customise which CSS classes and HTML tags the Carousel uses.', 'cpt-bootstrap-carousel').'</p>';
 	}
@@ -294,7 +322,7 @@ class cptbc_settings_page {
 	// Callback functions - print the form inputs
     // Carousel behaviour	
 	public function interval_callback() {
-			printf('<input type="text" id="interval" name="cptbc_settings[interval]" value="%s" size="6" />',
+			printf('<input type="text" id="interval" name="cptbc_settings[interval]" value="%s" size="15" />',
 					isset( $this->options['interval'] ) ? esc_attr( $this->options['interval']) : '');
             echo '<p class="description">'.__('How long each image shows for before it slides. Set to 0 to disable animation.', 'cpt-bootstrap-carousel').'</p>';
 	}
@@ -424,7 +452,7 @@ class cptbc_settings_page {
         echo '<p class="description">'.__("Experimental feature - Use CSS background images so that pictures auto-fill the space available.", 'cpt-bootstrap-carousel').'</p>';
 	}
 	public function background_images_height_callback() {
-		printf('<input type="text" id="background_images_height" name="cptbc_settings[background_images_height]" value="%s" size="6" />',
+		printf('<input type="text" id="background_images_height" name="cptbc_settings[background_images_height]" value="%s" size="15" />',
 				isset( $this->options['background_images_height'] ) ? esc_attr( $this->options['background_images_height']) : '500px');
         echo '<p class="description">'.__("If using background images above, how tall do you want the carousel to be?", 'cpt-bootstrap-carousel').'</p>';
 	}
@@ -444,53 +472,64 @@ class cptbc_settings_page {
 		print '</select>';
         echo '<p class="description">'.__("The Bootstrap Carousel is designed to work usign data-attributes. Sometimes the animation doesn't work correctly with this, so the default is to include a small portion of Javascript to fire the carousel. You can choose not to include this here.", 'cpt-bootstrap-carousel').'</p>';
 	}
-    
-    // Markup section
+
+	// Link buttons section
 	public function link_button_callback(){
 		print '<select id="link_button" name="cptbc_settings[link_button]">';
 		print '<option value="1"';
 		if(isset( $this->options['link_button'] ) && $this->options['link_button'] == 1){
 			print ' selected="selected"';
 		}
-		echo '>Yes (default)</option>';
+		echo '>Yes</option>';
 		print '<option value="0"';
-		if(isset( $this->options['link_button'] ) && $this->options['link_button'] == 0){
+		if(!isset( $this->options['link_button'] ) || $this->options['link_button'] == 0){
 			print ' selected="selected"';
 		}
-		echo '>No</option>';
+		echo '>No (Default)</option>';
 		print '</select>';
+		echo '<p class="description">'.__("If a URL is set for a carousel image, this option will create a button in the caption instead of linking the image itself.", 'cpt-bootstrap-carousel').'</p>';
 	}
 	public function link_button_text_callback() {
-			printf('<input type="text" id="link_button_text" name="cptbc_settings[link_button_text]" value="%s" size="15" />',
+			printf('<input type="text" id="link_button_text" name="cptbc_settings[link_button_text]" value="%s" size="20" />',
 					isset( $this->options['link_button_text'] ) ? esc_attr( $this->options['link_button_text']) : 'Read more');
 	}
-	public function before_title_callback() {
-			printf('<input type="text" id="link_button_class" name="cptbc_settings[link_button_class]" value="%s" size="6" />',
-					isset( $this->options['link_button_class'] ) ? esc_attr( $this->options['link_button_class']) : 'btn btn-default');
-			echo '<p class="description">'.__("Bootstrap style buttons must have the class <code>btn</code> and then one of the following: <code>btn-default</code>, <code>btn-primary</code>, <code>btn-success</code>, <code>btn-warning</code>, <code>btn-danger</code> or <code>btn-info</code>.", 'cpt-bootstrap-carousel').' <a href="http://getbootstrap.com/css/#buttons-options" target="_blank">Bootstrap documentation</a>.</p>';
+	public function link_button_class_callback() {
+			printf('<input type="text" id="link_button_class" name="cptbc_settings[link_button_class]" value="%s" size="20" />',
+					isset( $this->options['link_button_class'] ) ? esc_attr( $this->options['link_button_class']) : 'btn btn-default pull-right');
+			echo '<p class="description">'.__("Bootstrap style buttons must have the class <code>btn</code> and then one of the following: <code>btn-default</code>, <code>btn-primary</code>, <code>btn-success</code>, <code>btn-warning</code>, <code>btn-danger</code> or <code>btn-info</code>. No <code>.</code> prefixes. <code>pull-right</code> to float the button on the right. See the ", 'cpt-bootstrap-carousel').' <a href="http://getbootstrap.com/css/#buttons-options" target="_blank">Bootstrap documentation</a>.</p>';
 	}
+	public function link_button_before_callback() {
+			printf('<input type="text" id="link_button_before" name="cptbc_settings[link_button_before]" value="%s" size="20" />',
+					isset( $this->options['link_button_before'] ) ? esc_attr( $this->options['link_button_before']) : '');
+	}
+	public function link_button_after_callback() {
+			printf('<input type="text" id="link_button_after" name="cptbc_settings[link_button_after]" value="%s" size="20" />',
+					isset( $this->options['link_button_after'] ) ? esc_attr( $this->options['link_button_after']) : '');
+	}
+    
+    // Markup section
 	public function before_title_callback() {
-			printf('<input type="text" id="before_title" name="cptbc_settings[before_title]" value="%s" size="6" />',
+			printf('<input type="text" id="before_title" name="cptbc_settings[before_title]" value="%s" size="15" />',
 					isset( $this->options['before_title'] ) ? esc_attr( $this->options['before_title']) : '<h4>');
 	}
 	public function customnext_callback() {
-			printf('<input type="text" id="customnext" name="cptbc_settings[customnext]" value="%s" size="6" />',
+			printf('<input type="text" id="customnext" name="cptbc_settings[customnext]" value="%s" size="15" />',
 					isset( $this->options['customnext'] ) ? esc_attr( $this->options['customnext']) : '');
 	}
 	public function customprev_callback() {
-			printf('<input type="text" id="customprev" name="cptbc_settings[customprev]" value="%s" size="6" />',
+			printf('<input type="text" id="customprev" name="cptbc_settings[customprev]" value="%s" size="15" />',
 					isset( $this->options['customprev'] ) ? esc_attr( $this->options['customprev']) : '');
 	}
 	public function after_title_callback() {
-			printf('<input type="text" id="after_title" name="cptbc_settings[after_title]" value="%s" size="6" />',
+			printf('<input type="text" id="after_title" name="cptbc_settings[after_title]" value="%s" size="15" />',
 					isset( $this->options['after_title'] ) ? esc_attr( $this->options['after_title']) : '</h4>');
 	}
 	public function before_caption_callback() {
-			printf('<input type="text" id="before_caption" name="cptbc_settings[before_caption]" value="%s" size="6" />',
+			printf('<input type="text" id="before_caption" name="cptbc_settings[before_caption]" value="%s" size="15" />',
 					isset( $this->options['before_caption'] ) ? esc_attr( $this->options['before_caption']) : '<p>');
 	}
 	public function after_caption_callback() {
-			printf('<input type="text" id="after_caption" name="cptbc_settings[after_caption]" value="%s" size="6" />',
+			printf('<input type="text" id="after_caption" name="cptbc_settings[after_caption]" value="%s" size="15" />',
 					isset( $this->options['after_caption'] ) ? esc_attr( $this->options['after_caption']) : '</p>');
 	}	
 	

--- a/trunk/readme.txt
+++ b/trunk/readme.txt
@@ -64,7 +64,7 @@ As of version 1.5, nearly all of these options can be set in the CPT Bootstrap C
 
 = Credits =
 
-This plugin was written by @tallphil with help and suggestions from several others including (but not limited to) @reddo, @joshgerdes, @atnon, @grahamharper, @rchq, @oheijo, @smtk, @cla63 and @cookierebes.
+This plugin was written by @tallphil with help and suggestions from several others including (but not limited to) @reddo, @joshgerdes, @atnon, @grahamharper, @rchq, @oheijo, @smtk, @cla63, @cookierebes and @sipman.
 
 The Serbo-Croation translation was kindly provided by Borisa Djuraskovic from http://www.webhostinghub.com
 
@@ -156,6 +156,7 @@ You need to make sure that each image is the same height. You can do this by set
 * New settings option to rely on data-attributes only, without any Javascript chunks
 * Split the plugin into multiple files to make code easier to maintain
 * Re-wrote the settings page to make things clearer
+* Added new feature to have a link button instead of clickable slider image
 
 = 1.8.1 =
 * Bugfix. Apologies to anyone who ran into it and thanks to kylewhenderson for the spot.


### PR DESCRIPTION
New code originally authored by @sipman and extended by @ewels. Gives option in Settings to use a button link instead of the whole image as a link when carousel items have URLs. Can customise classes and text of buttons, including custom link text for each carousel item if desired.