### PR TITLE
Update cptbc-frontend.php for using background-images to not set the …

### DIFF
--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -115,7 +115,7 @@ function cptbc_frontend($atts){
 					$linkend = '</a>';
 				} ?>
 
-				<div class="<?php echo $atts['twbs'] == '4' ? 'carousel-' : ''; ?>item <?php echo $key == 0 ? 'active' : ''; ?>" id="cptbc-item-<?php echo $image['post_id']; ?>" <?php if($atts['use_background_images'] == 1){ echo ' style="height: '.$atts['background_images_height'].'px; background: url(\''.$image['img_src'].'\') no-repeat center center ; -webkit-background-size: ' . $atts['select_background_images_style_size'] . '; -moz-background-size: ' . $atts['select_background_images_style_size'] . '; -o-background-size: ' . $atts['select_background_images_style_size'] . '; background-size: ' . $atts['select_background_images_style_size'] . ';"'; } ?>>
+				<div class="<?php echo $atts['twbs'] == '4' ? 'carousel-' : ''; ?>item <?php echo $key == 0 ? 'active' : ''; ?>" id="cptbc-item-<?php echo $image['post_id']; ?>" <?php if($atts['use_background_images'] == 1){ echo ' style="' .(($atts['background_images_height'] != 0) ? 'height: ' . $atts['background_images_height'] . 'px; ' : "") . ' background: url(\''.$image['img_src'].'\') no-repeat center center ; -webkit-background-size: ' . $atts['select_background_images_style_size'] . '; -moz-background-size: ' . $atts['select_background_images_style_size'] . '; -o-background-size: ' . $atts['select_background_images_style_size'] . '; background-size: ' . $atts['select_background_images_style_size'] . ';"'; } ?>>
 					<?php
 					// Regular behaviour - display image with link around it
 					if($atts['use_background_images'] == 0){


### PR DESCRIPTION
…size of the div to zero.

When using the CSS background images option the height option is used to set the height of the carousel images. Besides there are cases where you want to set the height to a particular value, 0 does not make sense at all. In this case every carousel item is set to "height:0px" and you do not see anything. The code change suggests an if statement which checks the value of the option 'Height if using bkgrnd images (px)' ($atts['background_images_height']) for not beeing 0. If it is zero, there is no ouput, otherwise it will echo the saved value.