### PR TITLE
Set unique category name to distinguish from default Category

### DIFF
--- a/trunk/cpt-bootstrap-carousel.php
+++ b/trunk/cpt-bootstrap-carousel.php
@@ -56,7 +56,7 @@ function cptbc_post_type() {
 }
 // Create a taxonomy for the carousel post type
 function cptbc_taxonomies () {
-	$args = array('hierarchical' => true);
+	$args = array('hierarchical' => true, 'label' => 'Carousel Categories');
 	register_taxonomy( 'carousel_category', 'cptbc', $args );
 }
 add_action( 'init', 'cptbc_taxonomies', 0 );


### PR DESCRIPTION
Set a unique category name for the carousel's categories to avoid having to 'Categories' items when configuring menu's etc. Could potentially set 'show_in_nav_menus' => false to hide it altogether by default.