### PR TITLE
Added video support for YouTube & Vimeo

### DIFF
--- a/trunk/cpt-bootstrap-carousel.php
+++ b/trunk/cpt-bootstrap-carousel.php
@@ -56,7 +56,7 @@ function cptbc_post_type() {
 }
 // Create a taxonomy for the carousel post type
 function cptbc_taxonomies () {
-	$args = array('hierarchical' => true);
+	$args = array('hierarchical' => true, 'label' => 'Carousel Categories');
 	register_taxonomy( 'carousel_category', 'cptbc', $args );
 }
 add_action( 'init', 'cptbc_taxonomies', 0 );

--- a/trunk/cptbc-admin.php
+++ b/trunk/cptbc-admin.php
@@ -13,26 +13,26 @@
 
 // Add column in admin list view to show featured image
 // http://wp.tutsplus.com/tutorials/creative-coding/add-a-custom-column-in-posts-and-custom-post-types-admin-screen/
-function cptbc_get_featured_image($post_ID) {
-	$post_thumbnail_id = get_post_thumbnail_id($post_ID);
-	if ($post_thumbnail_id) {
-		$post_thumbnail_img = wp_get_attachment_image_src($post_thumbnail_id, 'featured_preview');
-		return $post_thumbnail_img[0];
-	}
+function cptbc_get_featured_image($post_ID) {  
+	$post_thumbnail_id = get_post_thumbnail_id($post_ID);  
+	if ($post_thumbnail_id) {  
+		$post_thumbnail_img = wp_get_attachment_image_src($post_thumbnail_id, 'featured_preview');  
+		return $post_thumbnail_img[0];  
+	}  
 }
-function cptbc_columns_head($defaults) {
-	$defaults['featured_image'] = __('Featured Image', 'cpt-bootstrap-carousel');
-	$defaults['category'] = __('Category', 'cpt-bootstrap-carousel');
-	return $defaults;
-}
-function cptbc_columns_content($column_name, $post_ID) {
-	if ($column_name == 'featured_image') {
-		$post_featured_image = cptbc_get_featured_image($post_ID);
-		if ($post_featured_image) {
-			echo '<a href="'.get_edit_post_link($post_ID).'"><img src="' . $post_featured_image . '" alt="" style="max-width:100%;" /></a>';
-		}
+function cptbc_columns_head($defaults) {  
+	$defaults['featured_image'] = __('Featured Image', 'cpt-bootstrap-carousel');  
+	$defaults['category'] = __('Category', 'cpt-bootstrap-carousel');  
+	return $defaults;  
+}  
+function cptbc_columns_content($column_name, $post_ID) {  
+	if ($column_name == 'featured_image') {  
+		$post_featured_image = cptbc_get_featured_image($post_ID);  
+		if ($post_featured_image) {  
+			echo '<a href="'.get_edit_post_link($post_ID).'"><img src="' . $post_featured_image . '" alt="" style="max-width:100%;" /></a>';  
+		}  
 	}
-	if ($column_name == 'category') {
+	if ($column_name == 'category') {  
 		$post_categories = get_the_terms($post_ID, 'carousel_category');
 		if ($post_categories) {
 			$output = '';
@@ -45,7 +45,7 @@ function cptbc_columns_content($column_name, $post_ID) {
 		}
 	}
 }
-add_filter('manage_cptbc_posts_columns', 'cptbc_columns_head');
+add_filter('manage_cptbc_posts_columns', 'cptbc_columns_head');  
 add_action('manage_cptbc_posts_custom_column', 'cptbc_columns_content', 10, 2);
 
 // Extra admin field for image URL
@@ -63,19 +63,19 @@ function cptbc_image_url(){
 		<input type="url" name="cptbc_image_url" value="<?php echo $cptbc_image_url; ?>" style="width: 100%"/> <br />
 		<small><em><?php _e('(optional - leave blank for no link)', 'cpt-bootstrap-carousel'); ?></em></small>
 	</p>
-
+	
 	<p>
 		<label>
 			<input type="checkbox" name="cptbc_image_url_openblank" <?php if($cptbc_image_url_openblank == 1){ echo ' checked="checked"'; } ?> value="1" /> <?php _e('Open link in new window?', 'cpt-bootstrap-carousel'); ?>
 		</label>
 	</p>
-
+	
 	<p>
 		<label><?php _e('Button Text', 'cpt-bootstrap-carousel'); ?>:</label>
 		<input type="text" name="cptbc_image_link_text" value="<?php echo $cptbc_image_link_text; ?>" style="width: 100%"/> <br />
 		<small><em><?php _e('(optional - leave blank for default, only shown if using link buttons)', 'cpt-bootstrap-carousel'); ?></em></small>
 	</p>
-
+	
 	<hr />
 
 	<p><strong>Note: Using a video replaces the slide text &amp; button (if shown), Youtube &amp; Vimeo are supported</strong></p>
@@ -128,38 +128,38 @@ function cptbc_contextual_help_tab() {
                 <p>You can read the full plugin documentation on the <a href="http://wordpress.org/plugins/cpt-bootstrap-carousel/" target="_blank">WordPress plugins page</a></p>
                 <p>Most settings can be changed in the <a href="">settings page</a> but you can also specify options for individual carousels
                 using the following settings:</p>
-
+		
                 <ul>
                 <li><code>interval</code> <em>(default 5000)</em>
                 <ul>
                 <li>Length of time for the caption to pause on each image. Time in milliseconds.</li>
                 </ul></li>
-
+			
                 <li><code>showcaption</code> <em>(default true)</em>
                 <ul>
                 <li>Whether to display the text caption on each image or not. true or false.</li>
                 </ul></li>
-
+			
                 <li><code>showcontrols</code> <em>(default true)</em>
                 <ul>
                 <li>Whether to display the control arrows or not. true or false.</li>
                 </ul></li>
-
+			
                 <li><code>orderby</code> and <code>order</code> <em>(default menu_order ASC)</em>
                 <ul>
                 <li>What order to display the posts in. Uses WP_Query terms.</li>
                 </ul></li>
-
+			
                 <li><code>category</code> <em>(default all)</em>
                 <ul>
                 <li>Filter carousel items by a comma separated list of carousel category slugs.</li>
                 </ul></li>
-
+			
                 <li><code>image_size</code> <em>(default full)</em>
                 <ul>
                 <li>WordPress image size to use, useful for small carousels</li>
                 </ul></li>
-
+			
                 <li><code>id</code> <em>(default all)</em>
                 <ul>
                 <li>Specify the ID of a specific carousel post to display only one image.</li>';
@@ -168,7 +168,7 @@ function cptbc_contextual_help_tab() {
         }
         $help .= '
             </ul></li>
-
+			
         <li><code>twbs</code> <em>(default 3)</em>
         <ul>
         <li>Output markup for Twitter Bootstrap Version 2, 3 or 4.</li>

--- a/trunk/cptbc-admin.php
+++ b/trunk/cptbc-admin.php
@@ -13,26 +13,26 @@
 
 // Add column in admin list view to show featured image
 // http://wp.tutsplus.com/tutorials/creative-coding/add-a-custom-column-in-posts-and-custom-post-types-admin-screen/
-function cptbc_get_featured_image($post_ID) {  
-	$post_thumbnail_id = get_post_thumbnail_id($post_ID);  
-	if ($post_thumbnail_id) {  
-		$post_thumbnail_img = wp_get_attachment_image_src($post_thumbnail_id, 'featured_preview');  
-		return $post_thumbnail_img[0];  
-	}  
-}
-function cptbc_columns_head($defaults) {  
-	$defaults['featured_image'] = __('Featured Image', 'cpt-bootstrap-carousel');  
-	$defaults['category'] = __('Category', 'cpt-bootstrap-carousel');  
-	return $defaults;  
-}  
-function cptbc_columns_content($column_name, $post_ID) {  
-	if ($column_name == 'featured_image') {  
-		$post_featured_image = cptbc_get_featured_image($post_ID);  
-		if ($post_featured_image) {  
-			echo '<a href="'.get_edit_post_link($post_ID).'"><img src="' . $post_featured_image . '" alt="" style="max-width:100%;" /></a>';  
-		}  
+function cptbc_get_featured_image($post_ID) {
+	$post_thumbnail_id = get_post_thumbnail_id($post_ID);
+	if ($post_thumbnail_id) {
+		$post_thumbnail_img = wp_get_attachment_image_src($post_thumbnail_id, 'featured_preview');
+		return $post_thumbnail_img[0];
 	}
-	if ($column_name == 'category') {  
+}
+function cptbc_columns_head($defaults) {
+	$defaults['featured_image'] = __('Featured Image', 'cpt-bootstrap-carousel');
+	$defaults['category'] = __('Category', 'cpt-bootstrap-carousel');
+	return $defaults;
+}
+function cptbc_columns_content($column_name, $post_ID) {
+	if ($column_name == 'featured_image') {
+		$post_featured_image = cptbc_get_featured_image($post_ID);
+		if ($post_featured_image) {
+			echo '<a href="'.get_edit_post_link($post_ID).'"><img src="' . $post_featured_image . '" alt="" style="max-width:100%;" /></a>';
+		}
+	}
+	if ($column_name == 'category') {
 		$post_categories = get_the_terms($post_ID, 'carousel_category');
 		if ($post_categories) {
 			$output = '';
@@ -45,7 +45,7 @@ function cptbc_columns_content($column_name, $post_ID) {
 		}
 	}
 }
-add_filter('manage_cptbc_posts_columns', 'cptbc_columns_head');  
+add_filter('manage_cptbc_posts_columns', 'cptbc_columns_head');
 add_action('manage_cptbc_posts_custom_column', 'cptbc_columns_content', 10, 2);
 
 // Extra admin field for image URL
@@ -55,29 +55,48 @@ function cptbc_image_url(){
 	$cptbc_image_url = isset($custom['cptbc_image_url']) ?  $custom['cptbc_image_url'][0] : '';
 	$cptbc_image_url_openblank = isset($custom['cptbc_image_url_openblank']) ?  $custom['cptbc_image_url_openblank'][0] : '0';
 	$cptbc_image_link_text = isset($custom['cptbc_image_link_text']) ?  $custom['cptbc_image_link_text'][0] : '';
+	$cptbc_video_url = isset($custom['cptbc_video_url']) ?  $custom['cptbc_video_url'][0] : '';
+	$cptbc_video_aspect = isset($custom['cptbc_video_aspect']) ?  $custom['cptbc_video_aspect'][0] : '';
 	?>
 	<p>
 		<label><?php _e('Image URL', 'cpt-bootstrap-carousel'); ?>:</label>
-		<input type="url" name="cptbc_image_url" value="<?php echo $cptbc_image_url; ?>" /> <br />
+		<input type="url" name="cptbc_image_url" value="<?php echo $cptbc_image_url; ?>" style="width: 100%"/> <br />
 		<small><em><?php _e('(optional - leave blank for no link)', 'cpt-bootstrap-carousel'); ?></em></small>
 	</p>
-	
+
 	<p>
 		<label>
 			<input type="checkbox" name="cptbc_image_url_openblank" <?php if($cptbc_image_url_openblank == 1){ echo ' checked="checked"'; } ?> value="1" /> <?php _e('Open link in new window?', 'cpt-bootstrap-carousel'); ?>
 		</label>
 	</p>
-	
+
 	<p>
 		<label><?php _e('Button Text', 'cpt-bootstrap-carousel'); ?>:</label>
-		<input type="text" name="cptbc_image_link_text" value="<?php echo $cptbc_image_link_text; ?>" /> <br />
+		<input type="text" name="cptbc_image_link_text" value="<?php echo $cptbc_image_link_text; ?>" style="width: 100%"/> <br />
 		<small><em><?php _e('(optional - leave blank for default, only shown if using link buttons)', 'cpt-bootstrap-carousel'); ?></em></small>
 	</p>
-	
+
+	<hr />
+
+	<p><strong>Note: Using a video replaces the slide text &amp; button (if shown), Youtube &amp; Vimeo are supported</strong></p>
+
+	<p>
+		<label><?php _e('Video URL', 'cpt-bootstrap-carousel'); ?>:</label>
+		<input type="text" name="cptbc_video_url" value="<?php echo $cptbc_video_url; ?>" style="width: 100%"/> <br />
+		<small><em><?php _e('(use only the url, not the full embed code)', 'cpt-bootstrap-carousel'); ?></em></small>
+	</p>
+
+	<p>
+		<label><?php _e('Video Aspect Ratio', 'cpt-bootstrap-carousel'); ?>:</label>
+		<select name="cptbc_video_aspect">
+			<option value="embed-responsive-16by9" <?php if ($cptbc_video_aspect == "embed-responsive-16by9") echo 'selected'; ?>>16:9</option>
+			<option value="embed-responsive-4by3" <?php if ($cptbc_video_aspect == "embed-responsive-4by3") echo 'selected'; ?>>4:3</option>
+		</select> <br />
+	</p>
 	<?php
 }
 function cptbc_admin_init_custpost(){
-	add_meta_box("cptbc_image_url", "Image Link URL", "cptbc_image_url", "cptbc", "side", "low");
+	add_meta_box("cptbc_image_url", "Slide Options", "cptbc_image_url", "cptbc", "side", "low");
 }
 add_action("add_meta_boxes", "cptbc_admin_init_custpost");
 function cptbc_mb_save_details(){
@@ -90,6 +109,10 @@ function cptbc_mb_save_details(){
 		update_post_meta($post->ID, "cptbc_image_url", esc_url($_POST["cptbc_image_url"]));
 		update_post_meta($post->ID, "cptbc_image_url_openblank", $openblank);
 		update_post_meta($post->ID, "cptbc_image_link_text", sanitize_text_field($_POST["cptbc_image_link_text"]));
+	}
+	if (isset($_POST["cptbc_video_url"])) {
+		update_post_meta($post->ID, "cptbc_video_url", esc_url($_POST["cptbc_video_url"]));
+		update_post_meta($post->ID, "cptbc_video_aspect", sanitize_text_field($_POST["cptbc_video_aspect"]));
 	}
 }
 add_action('save_post', 'cptbc_mb_save_details');
@@ -105,38 +128,38 @@ function cptbc_contextual_help_tab() {
                 <p>You can read the full plugin documentation on the <a href="http://wordpress.org/plugins/cpt-bootstrap-carousel/" target="_blank">WordPress plugins page</a></p>
                 <p>Most settings can be changed in the <a href="">settings page</a> but you can also specify options for individual carousels
                 using the following settings:</p>
-		
+
                 <ul>
                 <li><code>interval</code> <em>(default 5000)</em>
                 <ul>
                 <li>Length of time for the caption to pause on each image. Time in milliseconds.</li>
                 </ul></li>
-			
+
                 <li><code>showcaption</code> <em>(default true)</em>
                 <ul>
                 <li>Whether to display the text caption on each image or not. true or false.</li>
                 </ul></li>
-			
+
                 <li><code>showcontrols</code> <em>(default true)</em>
                 <ul>
                 <li>Whether to display the control arrows or not. true or false.</li>
                 </ul></li>
-			
+
                 <li><code>orderby</code> and <code>order</code> <em>(default menu_order ASC)</em>
                 <ul>
                 <li>What order to display the posts in. Uses WP_Query terms.</li>
                 </ul></li>
-			
+
                 <li><code>category</code> <em>(default all)</em>
                 <ul>
                 <li>Filter carousel items by a comma separated list of carousel category slugs.</li>
                 </ul></li>
-			
+
                 <li><code>image_size</code> <em>(default full)</em>
                 <ul>
                 <li>WordPress image size to use, useful for small carousels</li>
                 </ul></li>
-			
+
                 <li><code>id</code> <em>(default all)</em>
                 <ul>
                 <li>Specify the ID of a specific carousel post to display only one image.</li>';
@@ -145,7 +168,7 @@ function cptbc_contextual_help_tab() {
         }
         $help .= '
             </ul></li>
-			
+
         <li><code>twbs</code> <em>(default 3)</em>
         <ul>
         <li>Output markup for Twitter Bootstrap Version 2, 3 or 4.</li>

--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -223,9 +223,12 @@ function cptbc_frontend($atts){
 
 				// Check & load video auto pause requirements
 				if (count($video_providers) > 0) { ?>
+					<script>
+						var $myCarousel = jQuery('#cptbc_<?php echo $id; ?>');
+
 					<?php foreach ($video_providers as $provider):
 						if ($provider == 'youtube') { ?>
-						<script>
+
 							// See http://jsfiddle.net/8R5y6/
 							function callYoutubePlayer(frame_id, func, args) {
 							    if (window.jQuery && frame_id instanceof jQuery) frame_id = frame_id.get(0).id;
@@ -244,16 +247,17 @@ function cptbc_frontend($atts){
 							    }
 							}
 
-							var $myCarousel = jQuery('#cptbc_<?php echo $id; ?>');
+
 							$myCarousel.on("slide.bs.carousel", function (event) {
 								var $currentSlide = $myCarousel.find(".active iframe.provider-youtube");
 								if (!$currentSlide.length) { return; }
 								callYoutubePlayer($currentSlide, 'pauseVideo')
 							});
-						</script>
+
+
 						<?php }
 						if ($provider == 'vimeo') { ?>
-							<script>
+
 							// Youtube version hacked into vimeo version
 							function callVimeoPlayer(frame_id, action, args) {
 							    if (window.jQuery && frame_id instanceof jQuery) frame_id = frame_id.get(0).id;
@@ -271,16 +275,16 @@ function cptbc_frontend($atts){
 									}
 					    }
 
-							var $myCarousel = jQuery('#cptbc_<?php echo $id; ?>');
+
 							$myCarousel.on("slide.bs.carousel", function (event) {
 								var $currentSlide = $myCarousel.find(".active iframe.provider-vimeo");
 								if (!$currentSlide.length) { return; }
 								callVimeoPlayer($currentSlide, 'pause')
 							});
-							</script>
+
 						<?php }
 					endforeach; ?>
-					<script>
+
 
 					</script>
 				<?php }

--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -88,8 +88,7 @@ function cptbc_frontend($atts){
 		ob_start();
 		?>
 		<div id="cptbc_<?php echo $id; ?>" class="carousel slide" <?php if($atts['use_javascript_animation'] == '0'){ echo ' data-ride="carousel"'; } ?> data-interval="<?php echo $atts['interval']; ?>">
-
-
+			
 			<?php // First content - the carousel indicators
 			if( count( $images ) > 1 ){ ?>
 				<ol class="carousel-indicators">
@@ -103,12 +102,11 @@ function cptbc_frontend($atts){
 			<?php
 			// Carousel Content
 			foreach ($images as $key => $image) {
-
+				
 				if( !isset($atts['link_button']) ) {
 					$atts['link_button'] = 0;
 				}
-
-
+				
 				// Build anchor link so it can be reused
 				$linkstart = '';
 				$linkend = '';
@@ -147,49 +145,49 @@ function cptbc_frontend($atts){
 							</div>
 					<?php
 						} else {
-						if($atts['use_background_images'] == 0){
-							echo $linkstart.$image['image'].$linkend;
-						// Background images mode - need block level link inside carousel link if we have a linl
-						} else if($image['url'] && $atts['link_button'] == 0) {
-							echo '<a href="'.$image['url'].'"';
+					if($atts['use_background_images'] == 0){
+						echo $linkstart.$image['image'].$linkend;
+					// Background images mode - need block level link inside carousel link if we have a linl
+					} else if($image['url'] && $atts['link_button'] == 0) {
+						echo '<a href="'.$image['url'].'"';
+						if($image['url_openblank']) {
+							echo ' target="_blank"';
+						}
+						echo ' style="display:block; width:100%; height:100%;">&nbsp;</a>';
+					} 
+					// The Caption div
+					if(($atts['showtitle'] === 'true' && strlen($image['title']) > 0) || ($atts['showcaption'] === 'true' && strlen($image['content']) > 0) || ($image['url'] && $atts['link_button'] == 1))  {
+						if(isset($atts['before_caption_div'])) echo $atts['before_caption_div'];
+						echo '<div class="carousel-caption">';
+						// Title
+						if($atts['showtitle'] === 'true' && strlen($image['title']) > 0){
+							echo $atts['before_title'].$linkstart.$image['title'].$linkend.$atts['after_title'];
+						}
+						// Caption
+						if($atts['showcaption'] === 'true' && strlen($image['content']) > 0){
+							echo $atts['before_caption'].$linkstart.$image['content'].$linkend.$atts['after_caption'];
+						}
+						// Link Button
+						if($image['url'] && $atts['link_button'] == 1){ 
+							if(isset($atts['link_button_before'])) echo $atts['link_button_before'];
+							$target = '';
 							if($image['url_openblank']) {
-								echo ' target="_blank"';
+								$target = ' target="_blank"';
 							}
-							echo ' style="display:block; width:100%; height:100%;">&nbsp;</a>';
+							echo '<a href="'.$image['url'].'" '.$target.' class="'.$atts['link_button_class'].'">';
+							if(isset($image['link_text']) && strlen($image['link_text']) > 0) {
+								echo $image['link_text'];
+							} else {
+								echo $atts['link_button_text'];
+							}
+							echo '</a>';
+							if(isset($atts['link_button_after'])) echo $atts['link_button_after'];
 						}
-						// The Caption div
-						if(($atts['showtitle'] === 'true' && strlen($image['title']) > 0) || ($atts['showcaption'] === 'true' && strlen($image['content']) > 0) || ($image['url'] && $atts['link_button'] == 1))  {
-							if(isset($atts['before_caption_div'])) echo $atts['before_caption_div'];
-							echo '<div class="carousel-caption">';
-							// Title
-							if($atts['showtitle'] === 'true' && strlen($image['title']) > 0){
-								echo $atts['before_title'].$linkstart.$image['title'].$linkend.$atts['after_title'];
-							}
-							// Caption
-							if($atts['showcaption'] === 'true' && strlen($image['content']) > 0){
-								echo $atts['before_caption'].$linkstart.$image['content'].$linkend.$atts['after_caption'];
-							}
-							// Link Button
-							if($image['url'] && $atts['link_button'] == 1){
-								if(isset($atts['link_button_before'])) echo $atts['link_button_before'];
-								$target = '';
-								if($image['url_openblank']) {
-									$target = ' target="_blank"';
-								}
-								echo '<a href="'.$image['url'].'" '.$target.' class="'.$atts['link_button_class'].'">';
-								if(isset($image['link_text']) && strlen($image['link_text']) > 0) {
-									echo $image['link_text'];
-								} else {
-									echo $atts['link_button_text'];
-								}
-								echo '</a>';
-								if(isset($atts['link_button_after'])) echo $atts['link_button_after'];
-							}
-							echo '</div>';
-							if(isset($atts['after_caption_div'])) echo $atts['after_caption_div'];
+						echo '</div>';
+						if(isset($atts['after_caption_div'])) echo $atts['after_caption_div'];
 
-						}
-					} // End video if ?>
+					}
+				} // End video if ?>
 				</div>
 			<?php } ?>
 			</div>
@@ -228,7 +226,6 @@ function cptbc_frontend($atts){
 
 					<?php foreach ($video_providers as $provider):
 						if ($provider == 'youtube') { ?>
-
 							// See http://jsfiddle.net/8R5y6/
 							function callYoutubePlayer(frame_id, func, args) {
 							    if (window.jQuery && frame_id instanceof jQuery) frame_id = frame_id.get(0).id;
@@ -247,17 +244,14 @@ function cptbc_frontend($atts){
 							    }
 							}
 
-
 							$myCarousel.on("slide.bs.carousel", function (event) {
 								var $currentSlide = $myCarousel.find(".active iframe.provider-youtube");
 								if (!$currentSlide.length) { return; }
 								callYoutubePlayer($currentSlide, 'pauseVideo')
 							});
 
-
 						<?php }
 						if ($provider == 'vimeo') { ?>
-
 							// Youtube version hacked into vimeo version
 							function callVimeoPlayer(frame_id, action, args) {
 							    if (window.jQuery && frame_id instanceof jQuery) frame_id = frame_id.get(0).id;
@@ -275,17 +269,13 @@ function cptbc_frontend($atts){
 									}
 					    }
 
-
 							$myCarousel.on("slide.bs.carousel", function (event) {
 								var $currentSlide = $myCarousel.find(".active iframe.provider-vimeo");
 								if (!$currentSlide.length) { return; }
 								callVimeoPlayer($currentSlide, 'pause')
 							});
-
 						<?php }
 					endforeach; ?>
-
-
 					</script>
 				<?php }
 
@@ -295,10 +285,10 @@ function cptbc_frontend($atts){
 	} else {
 		$output = '<!-- CPT Bootstrap Carousel - no images found for #cptbc_'.$id.' -->';
 	}
-
+	
 	// Restore original Post Data
-	wp_reset_postdata();
-
+	wp_reset_postdata();  
+	
 	return $output;
 }
 


### PR DESCRIPTION
Added in video support for YouTube & Vimeo using extra fields to store video URL & aspect ratio setting, outputs them instead of the image & text. It supposed auto-pausing on slide away from the video. As apart of this I've renamed the Image Url box to 'Slide Options' and fixed a typo. Tested it on both background & normal image carousels - its responsive friendly.

I've added this as it's something our users have requested, if it's not suitable for the original or needs changes let me know. If I get some time I'll add in some action hooks to automatically retrieve & set the featured image to the video thumbnail if it isn't set already.