### PR TITLE
replace custom value with default control icons

### DIFF
--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -199,8 +199,8 @@ function cptbc_frontend($atts){
 			<?php // Previous / Next controls
 			if( count( $images ) > 1 ){
 				if( $atts['showcontrols'] === 'true' && $atts['twbs' ] == '3') { ?>
-					<a class="left carousel-control-left" href="#cptbc_<?php echo $id; ?>" data-slide="prev"><span class="glyphicon glyphicon-chevron-left"></span></a>
-					<a class="right carousel-control-right" href="#cptbc_<?php echo $id; ?>" data-slide="next"><span class="glyphicon glyphicon-chevron-right"></span></a>
+					<a class="left carousel-control" href="#cptbc_<?php echo $id; ?>" data-slide="prev"><span class="glyphicon glyphicon-chevron-left"></span></a>
+					<a class="right carousel-control" href="#cptbc_<?php echo $id; ?>" data-slide="next"><span class="glyphicon glyphicon-chevron-right"></span></a>
 				<?php } elseif ( $atts['showcontrols'] === 'true' && $atts['twbs'] == '4' ) { ?>
 					<a class="carousel-control-prev" role="button" href="#cptbc_<?php echo $id; ?>" data-slide="prev"><span class="carousel-control-prev-icon icon-prev"></span></a>
 					<a class="carousel-control-next" role="button" href="#cptbc_<?php echo $id; ?>" data-slide="next"><span class="carousel-control-next-icon icon-next"></span></a>

--- a/trunk/cptbc-frontend.php
+++ b/trunk/cptbc-frontend.php
@@ -202,8 +202,8 @@ function cptbc_frontend($atts){
 					<a class="left carousel-control-left" href="#cptbc_<?php echo $id; ?>" data-slide="prev"><span class="glyphicon glyphicon-chevron-left"></span></a>
 					<a class="right carousel-control-right" href="#cptbc_<?php echo $id; ?>" data-slide="next"><span class="glyphicon glyphicon-chevron-right"></span></a>
 				<?php } elseif ( $atts['showcontrols'] === 'true' && $atts['twbs'] == '4' ) { ?>
-					<a class="carousel-control-prev" role="button" href="#cptbc_<?php echo $id; ?>" data-slide="prev"><span class="<?php echo $atts['customprev'] ?> icon-prev"></span></a>
-					<a class="carousel-control-next" role="button" href="#cptbc_<?php echo $id; ?>" data-slide="next"><span class="<?php echo $atts['customnext'] ?> icon-next"></span></a>
+					<a class="carousel-control-prev" role="button" href="#cptbc_<?php echo $id; ?>" data-slide="prev"><span class="carousel-control-prev-icon icon-prev"></span></a>
+					<a class="carousel-control-next" role="button" href="#cptbc_<?php echo $id; ?>" data-slide="next"><span class="carousel-control-next-icon icon-next"></span></a>
 				<?php } elseif ( $atts['showcontrols'] === 'true' ) { ?>
 					<a class="left carousel-control" href="#cptbc_<?php echo $id; ?>" data-slide="prev">‹</a>
 					<a class="right carousel-control" href="#cptbc_<?php echo $id; ?>" data-slide="next">›</a>


### PR DESCRIPTION
On Bootstrap 4 default icons for prev/next control getting overwritten by the custom values. This adds on Version 4 the missing default buttons.